### PR TITLE
Prevent panic when decoding malformed data

### DIFF
--- a/src/dec.rs
+++ b/src/dec.rs
@@ -250,10 +250,10 @@ macro_rules! decode_raw (
 /// `source` buffer.
 pub fn decode(source: &[u8], dest: &mut[u8]) -> Result<usize, ()> {
     let mut dec = CobsDecoder::new(dest);
-    assert!(dec.push(source).unwrap().is_none());
+    assert!(dec.push(source).or(Err(()))?.is_none());
 
     // Explicitly push sentinel of zero
-    if let Some((d_used, _s_used)) = dec.push(&[0]).unwrap() {
+    if let Some((d_used, _s_used)) = dec.push(&[0]).or(Err(()))? {
         Ok(d_used)
     } else {
         Err(())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,10 +1,10 @@
-extern crate cobs;
+extern crate postcard_cobs;
 extern crate quickcheck;
 
 use quickcheck::{quickcheck, TestResult};
-use cobs::{max_encoding_length, encode, decode, encode_vec, decode_vec};
-use cobs::{encode_vec_with_sentinel, decode_vec_with_sentinel};
-use cobs::{CobsEncoder, CobsDecoder};
+use postcard_cobs::{max_encoding_length, encode, decode, encode_vec, decode_vec};
+use postcard_cobs::{encode_vec_with_sentinel, decode_vec_with_sentinel};
+use postcard_cobs::{CobsEncoder, CobsDecoder};
 
 fn test_pair(source: Vec<u8>, encoded: Vec<u8>) {
     let mut test_encoded = encoded.clone();
@@ -26,6 +26,17 @@ fn test_roundtrip(source: Vec<u8>) {
     let encoded = encode_vec(&source);
     let decoded = decode_vec(&encoded).expect("decode_vec");
     assert_eq!(source, decoded);
+}
+
+#[test]
+fn decode_malforemd() {
+    let malformed_buf: [u8;32] = [68, 69, 65, 68, 66, 69, 69, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut dest_buf : [u8;32] = [0;32];
+    if let Err(()) = decode(&malformed_buf, &mut dest_buf){
+        return;
+    } else {
+        assert!(false, "invalid test result.");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Prevents `postcard_cobs::decode` from panicking when asked to decode a malformed buffer.
Instead, it will return the `Err(())` variant to indicate the decode failed.

This is easier to handle in an embedded context, since the ability to catch unwindable panics is not present in the `core` crate.

Oh, and the test suite appeared to be broken (still based on the upstream `cobs` crate), so this PR fixes that. I added an additional test to ensure test decoding malformed buffers didn't create any other odd behaviors.